### PR TITLE
fix: add comment so action runs

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -1,4 +1,4 @@
-name: Build and Push Chart to OCI Regsitry
+name: Build and Push Chart to OCI Regsitry #
 description: Builds and pushes a Helm chart to an OCI registry
 inputs:
   chart-path: ""


### PR DESCRIPTION
Refer to this PR for the actual changes [https://github.com/atomicfi/action-build-push-chart-oci-registry/pull/2](https://github.com/atomicfi/action-build-push-chart-oci-registry/pull/2)

The workflow should only be updated with new versions most of the time, so the `on` event is still for `action.yaml`